### PR TITLE
change open to show in dialog demo docs

### DIFF
--- a/src/demo-app/components/dialog-demo/dialog-demo.component.html
+++ b/src/demo-app/components/dialog-demo/dialog-demo.component.html
@@ -36,7 +36,7 @@
       </thead>
       <tbody>
         <tr>
-          <td>open()</td>
+          <td>show()</td>
           <td>Opens the dialog, registers appropriate event listeners, sets aria attributes, focuses elements.</td>
         </tr>
         <tr>
@@ -179,7 +179,7 @@
   <span style="color:#89bdff">&lt;<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-dialog-footer</span>></span>
     <span style="color:#e0c589">&lt;<span style="color:#e0c589">button</span> <span style="color:#e0c589">mdc-dialog-button</span> [<span style="color:#e0c589">cancel</span>]=<span style="color:#65b042">"true"</span>></span>Decline<span style="color:#e0c589">&lt;/<span style="color:#e0c589">button</span>></span>
     <span style="color:#e0c589">&lt;<span style="color:#e0c589">button</span> <span style="color:#e0c589">mdc-dialog-button</span> [<span style="color:#e0c589">action</span>]=<span style="color:#65b042">"true"</span> [<span style="color:#e0c589">accept</span>]=<span style="color:#65b042">"true"</span>></span>Accept<span style="color:#e0c589">&lt;/<span style="color:#e0c589">button</span>></span>
-  <span style="color:#89bdff">&lt;/<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-dialog-footer</span>></span> 
+  <span style="color:#89bdff">&lt;/<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-dialog-footer</span>></span>
 <span style="color:#89bdff">&lt;/<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-dialog</span>></span>
 </pre>
 
@@ -276,7 +276,7 @@
   <mdc-dialog-footer>
     <button mdc-dialog-button [cancel]="true">Decline</button>
     <button mdc-dialog-button [action]="true" [accept]="true">Accept</button>
-  </mdc-dialog-footer> 
+  </mdc-dialog-footer>
 </mdc-dialog>
 
 <mdc-dialog #dialogalert [clickOutsideToClose]="false">


### PR DESCRIPTION
The method for opening a dialog seems to be `show()`, although documented as `open()`. This brings the demo app documentation in line with the code.