### PR TITLE
feat(toolbar): Rename Toolbar menu icon directive

### DIFF
--- a/src/demo-app/components/drawer-demo/drawer-demo.html
+++ b/src/demo-app/components/drawer-demo/drawer-demo.html
@@ -389,7 +389,7 @@
         <mdc-toolbar>
             <mdc-toolbar-row>
                 <mdc-toolbar-section [alignStart]="true">
-                    <button mdc-toolbar-icon-menu material-icon (click)="handlePersistent();">menu</button>
+                    <button mdc-toolbar-menu-icon material-icon (click)="handlePersistent();">menu</button>
                     <span mdc-toolbar-title>App</span>
                 </mdc-toolbar-section>
                 <mdc-toolbar-section [alignEnd]="true">

--- a/src/demo-app/components/toolbar-demo/toolbar-demo.html
+++ b/src/demo-app/components/toolbar-demo/toolbar-demo.html
@@ -111,22 +111,12 @@ So when it is minimized, ratio equals to 0 and when it is maximized, ratio equal
                     <td>Optional directive to add a default margin-top to mdc-toolbar's adjacent sibling element.</td>
                 </tr>
                 <tr>
-                    <td>mdc-toolbar-icon-menu</td>
-                    <td>Left most icon of a mdc-toolbar.
-                        <pre><code><![CDATA[a[mdc-toolbar-icon-menu]
-button[mdc-toolbar-icon-menu]
-span[mdc-toolbar-icon-menu]
-]]></code></pre>
-                    </td>
+                    <td>mdc-toolbar-menu-icon</td>
+                    <td>Left most icon of a mdc-toolbar.</td>
                 </tr>
                 <tr>
                     <td>mdc-toolbar-icon</td>
-                    <td>Icons placed on the right side of a mdc-toolbar.
-                        <pre><code><![CDATA[a[mdc-toolbar-icon]
-button[mdc-toolbar-icon]
-span[mdc-toolbar-icon]
-]]></code></pre>
-                    </td>
+                    <td>Icons placed on the right side of a mdc-toolbar.</td>
                 </tr>
             </tbody>
         </table>
@@ -153,7 +143,7 @@ span[mdc-toolbar-icon]
         <mdc-toolbar [flexible]="isFlexible" [fixed]="isFixed" [waterfall]="isWaterfall" [fixedLastrow]="isFixedLastRow" (change)="handleToolbarChange($event);">
             <mdc-toolbar-row>
                 <mdc-toolbar-section [alignStart]="true">
-                    <a href="#/toolbar-demo" mdc-toolbar-icon-menu material-icon>menu</a>
+                    <a href="#/toolbar-demo" mdc-toolbar-menu-icon material-icon>menu</a>
                     <mdc-toolbar-title>App Title</mdc-toolbar-title>
                 </mdc-toolbar-section>
             </mdc-toolbar-row>
@@ -174,7 +164,7 @@ span[mdc-toolbar-icon]
   (<span style="color:#89bdff">change</span>)=<span style="color:#65b042">"handleToolbarChange($event);"</span>></span>
   <span style="color:#89bdff">&lt;<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-toolbar-row</span>></span>
     <span style="color:#89bdff">&lt;<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-toolbar-section</span> [<span style="color:#89bdff">alignStart</span>]=<span style="color:#65b042">"true"</span>></span>
-      <span style="color:#e0c589">&lt;<span style="color:#e0c589">a</span> <span style="color:#e0c589">href</span>=<span style="color:#65b042">"#"</span> <span style="color:#e0c589">mdc-toolbar-icon-menu</span> <span style="color:#e0c589">material-icon</span>></span>menu<span style="color:#e0c589">&lt;/<span style="color:#e0c589">a</span>></span>
+      <span style="color:#e0c589">&lt;<span style="color:#e0c589">a</span> <span style="color:#e0c589">href</span>=<span style="color:#65b042">"#"</span> <span style="color:#e0c589">mdc-toolbar-menu-icon</span> <span style="color:#e0c589">material-icon</span>></span>menu<span style="color:#e0c589">&lt;/<span style="color:#e0c589">a</span>></span>
       <span style="color:#e0c589">&lt;<span style="color:#e0c589">mdc-toolbar-title</span>></span>App Title<span style="color:#e0c589">&lt;/<span style="color:#e0c589">mdc-toolbar-title</span>></span>
     <span style="color:#89bdff">&lt;/<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-toolbar-section</span>></span>
   <span style="color:#89bdff">&lt;/<span style="color:#89bdff">mdc</span><span style="color:#89bdff">-toolbar-row</span>></span>

--- a/src/demo-app/navigation/app-toolbar.html
+++ b/src/demo-app/navigation/app-toolbar.html
@@ -1,8 +1,8 @@
 <mdc-toolbar class="demo-toolbar--primary" [fixed]="isFixed">
   <mdc-toolbar-row>
     <mdc-toolbar-section [alignStart]="true">
-      <button material-icon mdc-toolbar-icon-menu (click)="toggleDrawer();" fxShow fxHide.gt-xs="true">menu</button>
-      <a class="demo-toolbar-logo" button mdc-toolbar-icon-menu fxHide fxShow.gt-xs="true" [routerLink]="['home']" [mdc-ripple]="true">
+      <button material-icon mdc-toolbar-menu-icon (click)="toggleDrawer();" fxShow fxHide.gt-xs="true">menu</button>
+      <a class="demo-toolbar-logo" button mdc-toolbar-menu-icon fxHide fxShow.gt-xs="true" [routerLink]="['home']" [mdc-ripple]="true">
        <img src="https://trimox.github.io/angular-mdc-web/assets/hub-192x192.png" width="28" height="28" />
      </a>
       <mdc-toolbar-title>

--- a/src/lib/toolbar/index.ts
+++ b/src/lib/toolbar/index.ts
@@ -5,8 +5,8 @@ import { MdcToolbarRowDirective } from './toolbar-row.directive';
 import { MdcToolbarSectionDirective } from './toolbar-section.directive';
 import { MdcToolbarTitleDirective } from './toolbar-title.directive';
 import { MdcToolbarFixedAdjustDirective } from './toolbar-fixed-adjust.directive';
-import { MdcToolbarIconDirective } from './toolbar-icon.directive';
-import { MdcToolbarIconMenuDirective } from './toolbar-icon-menu.directive';
+import { MdcToolbarIcon } from './toolbar-icon.directive';
+import { MdcToolbarIconMenu } from './toolbar-icon-menu.directive';
 
 const TOOLBAR_COMPONENTS = [
   MdcToolbarComponent,
@@ -14,8 +14,8 @@ const TOOLBAR_COMPONENTS = [
   MdcToolbarSectionDirective,
   MdcToolbarTitleDirective,
   MdcToolbarFixedAdjustDirective,
-  MdcToolbarIconDirective,
-  MdcToolbarIconMenuDirective
+  MdcToolbarIcon,
+  MdcToolbarIconMenu
 ];
 
 @NgModule({

--- a/src/lib/toolbar/toolbar-icon-menu.directive.ts
+++ b/src/lib/toolbar/toolbar-icon-menu.directive.ts
@@ -5,10 +5,10 @@ import {
 } from '@angular/core';
 
 @Directive({
-  selector: 'a[mdc-toolbar-icon-menu], span[mdc-toolbar-icon-menu], button[mdc-toolbar-icon-menu]'
+  selector: '[mdc-toolbar-menu-icon]'
 })
-export class MdcToolbarIconMenuDirective {
-  @HostBinding('class.mdc-toolbar__icon--menu') isHostClass = true;
+export class MdcToolbarIconMenu {
+  @HostBinding('class.mdc-toolbar__menu-icon') isHostClass = true;
 
   constructor(public elementRef: ElementRef) { }
 }

--- a/src/lib/toolbar/toolbar-icon.directive.ts
+++ b/src/lib/toolbar/toolbar-icon.directive.ts
@@ -5,9 +5,9 @@ import {
 } from '@angular/core';
 
 @Directive({
-  selector: 'a[mdc-toolbar-icon], span[mdc-toolbar-icon], button[mdc-toolbar-icon]'
+  selector: '[mdc-toolbar-icon]'
 })
-export class MdcToolbarIconDirective {
+export class MdcToolbarIcon {
   @HostBinding('class.mdc-toolbar__icon') isHostClass = true;
 
   constructor(public elementRef: ElementRef) { }

--- a/test/unit/toolbar/toolbar.test.ts
+++ b/test/unit/toolbar/toolbar.test.ts
@@ -91,7 +91,7 @@ describe('MdcToolbarComponent', () => {
       (change)="handleToolbarChange($event);">
       <mdc-toolbar-row>
         <mdc-toolbar-section [alignStart]="true">
-          <a href="#" mdc-toolbar-icon-menu material-icon>menu</a>
+          <a href="#" mdc-toolbar-menu-icon material-icon>menu</a>
           <mdc-toolbar-title>App Title</mdc-toolbar-title>
         </mdc-toolbar-section>
       </mdc-toolbar-row>


### PR DESCRIPTION
Change required as of MDC v0.23.0.
Reference https://github.com/material-components/material-components-web/pull/1373

- [x] Rename `mdc-toolbar-icon-menu` to `mdc-toolbar-menu-icon`.
- [x] Include breaking change notice
- [x] Update demo-app
- [x] Update unit tests

BREAKING CHANGE: Renamed `mdc-toolbar-icon-menu` to `mdc-toolbar-menu-icon` per MDC. Please update your code accordingly.

Closes #288