### PR TITLE
fix(chip): Set default value of 'removable' to be true

### DIFF
--- a/packages/chips/chip.ts
+++ b/packages/chips/chip.ts
@@ -192,7 +192,7 @@ export class MdcChip implements AfterViewInit, OnDestroy {
     this._foundation.setShouldRemoveOnTrailingIconClick(this._removable);
     this._changeDetectorRef.markForCheck();
   }
-  private _removable: boolean;
+  private _removable: boolean = true;
 
   /** Whether the chip is disabled. */
   @Input()


### PR DESCRIPTION
I found that `chip`'s `removed` did not emit the event because of `removable` was not set. The document stated that `removable` has default value of `true` but the source code does the otherwise.