### PR TITLE
feat(form-field): Add MdcFormFieldDefaultOptions injection token

### DIFF
--- a/packages/card/card.ts
+++ b/packages/card/card.ts
@@ -13,9 +13,7 @@ import { MdcRipple } from '@angular-mdc/web/ripple';
 @Directive({
   selector: 'mdc-card-media-content, [mdcCardMediaContent]',
   exportAs: 'mdcCardMediaContent',
-  host: {
-    'class': 'mdc-card__media-content',
-  }
+  host: { 'class': 'mdc-card__media-content' }
 })
 export class MdcCardMediaContent {
   constructor(public elementRef: ElementRef<HTMLElement>) { }
@@ -56,9 +54,7 @@ export class MdcCardMedia {
   moduleId: module.id,
   selector: 'mdc-card-primary-action, [mdcCardPrimaryAction]',
   exportAs: 'mdcCardPrimaryAction',
-  host: {
-    'class': 'mdc-card__primary-action'
-  },
+  host: { 'class': 'mdc-card__primary-action' },
   template: '<ng-content></ng-content>',
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -103,9 +99,7 @@ export class MdcCardActions {
 @Directive({
   selector: 'mdc-card-action-buttons, [mdcCardActionButtons]',
   exportAs: 'mdcCardActionButtons',
-  host: {
-    'class': 'mdc-card__action-buttons'
-  }
+  host: { 'class': 'mdc-card__action-buttons' }
 })
 export class MdcCardActionButtons {
   constructor(public elementRef: ElementRef<HTMLElement>) { }
@@ -114,9 +108,7 @@ export class MdcCardActionButtons {
 @Directive({
   selector: 'mdc-card-action-icons, [mdcCardActionIcons]',
   exportAs: 'mdcCardActionIcons',
-  host: {
-    'class': 'mdc-card__action-icons'
-  }
+  host: { 'class': 'mdc-card__action-icons' }
 })
 export class MdcCardActionIcons {
   constructor(public elementRef: ElementRef<HTMLElement>) { }
@@ -124,9 +116,7 @@ export class MdcCardActionIcons {
 
 @Directive({
   selector: '[mdcCardAction]',
-  host: {
-    'class': 'mdc-card__action'
-  }
+  host: { 'class': 'mdc-card__action' }
 })
 export class MdcCardAction {
   @Input('mdcCardAction')

--- a/packages/dialog/dialog-directives.ts
+++ b/packages/dialog/dialog-directives.ts
@@ -14,8 +14,8 @@ import { MdcRipple } from '@angular-mdc/web/ripple';
 @Directive({ selector: '[mdcDialogAction]' })
 export class MdcDialogAction {
   @Input('mdcDialogAction')
-  get action(): string | null { return this._action; }
-  set action(action: string | null) {
+  get action(): string { return this._action; }
+  set action(action: string) {
     // If the directive is set without a name (updated programatically), then this setter will
     // trigger with an empty string and should not overwrite the programatically set value.
     if (!action) { return; }
@@ -23,7 +23,7 @@ export class MdcDialogAction {
     this._action = action;
     this.elementRef.nativeElement.setAttribute('data-mdc-dialog-action', this._action);
   }
-  private _action: string | null = null;
+  private _action: string = '';
 
   constructor(public elementRef: ElementRef<HTMLElement>) { }
 }

--- a/packages/dialog/dialog-directives.ts
+++ b/packages/dialog/dialog-directives.ts
@@ -11,9 +11,7 @@ import { MdcButton } from '@angular-mdc/web/button';
 import { toBoolean } from '@angular-mdc/web/common';
 import { MdcRipple } from '@angular-mdc/web/ripple';
 
-@Directive({
-  selector: '[mdcDialogAction]',
-})
+@Directive({ selector: '[mdcDialogAction]' })
 export class MdcDialogAction {
   @Input('mdcDialogAction')
   get action(): string | null { return this._action; }

--- a/packages/dialog/dialog-portal.ts
+++ b/packages/dialog/dialog-portal.ts
@@ -1,14 +1,10 @@
 import {
   Component,
   ComponentRef,
-  ElementRef,
   EmbeddedViewRef,
-  Inject,
-  Optional,
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
 import { Subject } from 'rxjs';
 import {
   BasePortalOutlet,
@@ -69,12 +65,7 @@ export class MdcDialogPortal extends BasePortalOutlet {
     return this._portalOutlet.attachTemplatePortal(portal);
   }
 
-  constructor(
-    private _elementRef: ElementRef<HTMLElement>,
-    @Optional() @Inject(DOCUMENT) private _document: any,
-    /** The dialog configuration. */
-    public _config: MdcDialogConfig) {
-
+  constructor(public _config: MdcDialogConfig) {
     super();
   }
 }

--- a/packages/dialog/dialog.component.ts
+++ b/packages/dialog/dialog.component.ts
@@ -151,8 +151,6 @@ export class MdcDialogComponent implements AfterViewInit, OnDestroy {
   }
 
   private _initialize(): void {
-    if (!this.config) { return; }
-
     this._scrollable = !!this.config.scrollable;
 
     if (!this.config.clickOutsideToClose) {
@@ -194,8 +192,7 @@ export class MdcDialogComponent implements AfterViewInit, OnDestroy {
 
   private _loadListeners(): void {
     this._layoutEventSubscription = this.layoutEvents.pipe()
-      .subscribe(() =>
-        this._ngZone.runOutsideAngular(() => this._foundation.layout()));
+      .subscribe(() => this._foundation.layout());
 
     if (this._platform.isBrowser) {
       this._ngZone.runOutsideAngular(() =>

--- a/packages/form-field/form-field.ts
+++ b/packages/form-field/form-field.ts
@@ -5,10 +5,13 @@ import {
   ContentChild,
   ContentChildren,
   ElementRef,
+  Inject,
+  InjectionToken,
   Input,
   NgZone,
   OnDestroy,
   OnInit,
+  Optional,
   QueryList,
   ViewEncapsulation
 } from '@angular/core';
@@ -20,6 +23,25 @@ import { toBoolean } from '@angular-mdc/web/common';
 import { MdcFormFieldControl } from './form-field-control';
 import { MdcHelperText } from './helper-text';
 
+/** All possible variants for mdc-form-field. */
+export type MdcFormFieldVariant = 'fullwidth' | 'outlined' | undefined;
+
+/**
+ * Represents the default options for mdc-form-field that can be configured
+ * using an `MDC_FORM_FIELD_DEFAULT_OPTIONS` injection token.
+ */
+export interface MdcFormFieldDefaultOptions {
+  variant?: MdcFormFieldVariant;
+  disabled?: boolean;
+}
+
+/**
+ * Injection token that can be used to configure the default options for all
+ * mdc-form-field usage within an app.
+ */
+export const MDC_FORM_FIELD_DEFAULT_OPTIONS =
+  new InjectionToken<MdcFormFieldDefaultOptions>('MDC_FORM_FIELD_DEFAULT_OPTIONS');
+
 @Component({
   moduleId: module.id,
   selector: 'mdc-form-field',
@@ -30,16 +52,24 @@ import { MdcHelperText } from './helper-text';
   },
   template: `
   <ng-content></ng-content>
-  <ng-content select="[mdcHelperText, mdc-helper-text]"></ng-content>
-  `,
+  <ng-content select="[mdcHelperText, mdc-helper-text]"></ng-content>`,
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MdcFormField implements AfterContentInit, OnInit, OnDestroy {
   /** Emits whenever the component is destroyed. */
-  private _destroy = new Subject<void>();
+  private _destroyed = new Subject<void>();
 
-  public label!: HTMLElement;
+  public label?: HTMLElement;
+
+  @Input()
+  get variant(): MdcFormFieldVariant { return this._variant; }
+  set variant(value: MdcFormFieldVariant) {
+    if (value !== this._variant) {
+      this._variant = value || (this._defaults && this._defaults.variant) || undefined;
+    }
+  }
+  private _variant?: MdcFormFieldVariant;
 
   @Input()
   get fluid(): boolean { return this._fluid; }
@@ -60,26 +90,27 @@ export class MdcFormField implements AfterContentInit, OnInit, OnDestroy {
 
   constructor(
     private _ngZone: NgZone,
-    public elementRef: ElementRef<HTMLElement>) { }
+    public elementRef: ElementRef<HTMLElement>,
+    @Optional() @Inject(MDC_FORM_FIELD_DEFAULT_OPTIONS) private _defaults: MdcFormFieldDefaultOptions) {
+
+    this.variant = (_defaults && _defaults.variant) ? _defaults.variant : undefined;
+  }
 
   ngOnInit(): void {
     if (this._control) {
       const control = this._control.elementRef.nativeElement;
 
-      if (control.nextElementSibling) {
-        if (control.nextElementSibling.tagName === 'LABEL') {
-          this.label = control.nextElementSibling;
-          this.label.setAttribute('for', this._control.inputId || '');
-
-          this._loadListeners();
-        }
+      if (control.nextElementSibling && control.nextElementSibling.tagName === 'LABEL') {
+        this.label = control.nextElementSibling;
+        this.label!.setAttribute('for', this._control.inputId || '');
+        this._loadListeners();
       }
     }
   }
 
   ngAfterContentInit(): void {
     // When assistive elements change, initialize foundation
-    this.assistiveElements.changes.pipe(startWith(null), takeUntil(this._destroy))
+    this.assistiveElements.changes.pipe(startWith(null), takeUntil(this._destroyed))
       .subscribe(() => {
         (this.assistiveElements).forEach(helperText => {
           this._initHelperTextFoundation(helperText);
@@ -88,8 +119,8 @@ export class MdcFormField implements AfterContentInit, OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._destroy.next();
-    this._destroy.complete();
+    this._destroyed.next();
+    this._destroyed.complete();
   }
 
   private _initHelperTextFoundation(helperText: MdcHelperText): void {
@@ -102,7 +133,7 @@ export class MdcFormField implements AfterContentInit, OnInit, OnDestroy {
 
   private _loadListeners(): void {
     this._ngZone.runOutsideAngular(() =>
-      fromEvent<MouseEvent>(this.label, 'click').pipe(takeUntil(this._destroy))
+      fromEvent<MouseEvent>(this.label!, 'click').pipe(takeUntil(this._destroyed))
         .subscribe(() => this._ngZone.run(() => {
           this._control.ripple!.activateRipple();
 

--- a/test/card/card.test.ts
+++ b/test/card/card.test.ts
@@ -1,12 +1,11 @@
 import { Component, DebugElement } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import {
   MdcCardModule,
   MdcCard,
   MdcCardMedia,
-  MdcCardMediaContent,
   MdcCardAction,
   MdcIconModule
 } from '@angular-mdc/web';
@@ -14,7 +13,7 @@ import {
 describe('MdcCard', () => {
   let fixture: ComponentFixture<any>;
 
-  beforeEach(async(() => {
+  beforeEach(fakeAsync(() => {
     TestBed.configureTestingModule({
       imports: [MdcCardModule, MdcIconModule],
       declarations: [SimpleTest]
@@ -38,7 +37,6 @@ describe('MdcCard', () => {
       fixture.detectChanges();
 
       testDebugElement = fixture.debugElement.query(By.directive(MdcCard));
-
       testActionButtonDebugElement = fixture.debugElement.query(By.directive(MdcCardAction));
       testActionButtonInstance = testActionButtonDebugElement.injector.get<MdcCardAction>(MdcCardAction);
 
@@ -64,6 +62,12 @@ describe('MdcCard', () => {
       fixture.detectChanges();
       expect(testActionButtonInstance.action).toBe('button');
     });
+
+    it('#should set action button to icon', () => {
+      testComponent.cardAction = 'icon';
+      fixture.detectChanges();
+      expect(testActionButtonInstance.action).toBe('icon');
+    });
   });
 });
 
@@ -78,6 +82,7 @@ describe('MdcCard', () => {
         </mdc-card-media>
       </mdc-card-primary-action>
       <mdc-card-actions [fullBleed]="fullBleed">
+        <div [mdcCardAction]="cardAction"></div>
         <mdc-card-action-buttons>
           <button mdc-button mdcCardAction="button">Action 2</button>
         </mdc-card-action-buttons>

--- a/test/dialog/dialog.test.ts
+++ b/test/dialog/dialog.test.ts
@@ -155,6 +155,41 @@ describe('MdcDialog Service', () => {
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
   });
 
+  it('should restore `aria-hidden` to the overlay container siblings on close', fakeAsync(() => {
+    const sibling = document.createElement('div');
+
+    sibling.setAttribute('aria-hidden', 'true');
+    overlayContainerElement.parentNode!.appendChild(sibling);
+
+    const dialogRef = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(sibling.getAttribute('aria-hidden')).toBe('true', 'Expected sibling to be hidden.');
+
+    dialogRef.close();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(sibling.getAttribute('aria-hidden')).toBe('true', 'Expected sibling to remain hidden.');
+    sibling.parentNode!.removeChild(sibling);
+  }));
+
+  it('should not set `aria-hidden` on `aria-live` elements', fakeAsync(() => {
+    const sibling = document.createElement('div');
+
+    sibling.setAttribute('aria-live', 'polite');
+    overlayContainerElement.parentNode!.appendChild(sibling);
+
+    dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(sibling.hasAttribute('aria-hidden'))
+      .toBe(false, 'Expected live element not to be hidden.');
+    sibling.parentNode!.removeChild(sibling);
+  }));
+
   it('should notify the observers if all open dialogs have finished closing', fakeAsync(() => {
     const ref1 = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
     const ref2 = dialog.open(SimpleDialog, { viewContainerRef: testViewContainerRef });

--- a/test/dialog/dialog.test.ts
+++ b/test/dialog/dialog.test.ts
@@ -1,14 +1,19 @@
-import { NgModule, Directive, Component, Injector, TemplateRef, ViewContainerRef, ViewChild } from '@angular/core';
-import { inject, ComponentFixture, fakeAsync, TestBed, flush } from '@angular/core/testing';
+import {
+  NgModule, Directive, Component, Inject,
+  Injector, TemplateRef, ViewContainerRef, ViewChild
+} from '@angular/core';
+import { inject, flush, fakeAsync, flushMicrotasks, tick, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Location } from '@angular/common';
 import { SpyLocation } from '@angular/common/testing';
 
 import { dispatchKeyboardEvent, dispatchFakeEvent } from '../testing/dispatch-events';
 
 import {
+  A,
   ESCAPE,
   DOWN_ARROW,
   MdcDialog,
+  MDC_DIALOG_DATA,
   MdcDialogModule,
   MdcDialogRef,
   OverlayContainer
@@ -23,14 +28,14 @@ describe('MdcDialog Service', () => {
   let viewContainerFixture: ComponentFixture<ComponentWithChildViewContainer>;
   let mockLocation: SpyLocation;
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [MdcDialogModule, DialogTestModule],
       providers: [{ provide: Location, useClass: SpyLocation }]
     });
 
     TestBed.compileComponents();
-  }));
+  });
 
   beforeEach(inject([MdcDialog, Location, OverlayContainer],
     (d: MdcDialog, l: Location, oc: OverlayContainer) => {
@@ -85,43 +90,91 @@ describe('MdcDialog Service', () => {
     dialogRef.close();
   });
 
-  it('#should open a simple dialog', fakeAsync(() => {
+  it('#should open a simple dialog', () => {
     const dialogRef = dialog.open(SimpleDialog);
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
     viewContainerFixture.detectChanges();
-    flush();
 
     const actionButtonDebugElement = overlayContainerElement.querySelector('button');
     dispatchFakeEvent(actionButtonDebugElement, 'click');
     viewContainerFixture.detectChanges();
-    flush();
-  }));
+  });
 
-  it('#should close using escape key', fakeAsync(() => {
+  it('#should close using escape key', () => {
     const dialogRef = dialog.open(SimpleDialog);
     viewContainerFixture.detectChanges();
-    flush();
 
     dispatchKeyboardEvent(document.body, 'keydown', ESCAPE);
     viewContainerFixture.detectChanges();
-    flush();
-  }));
+  });
 
-  it('#should open a simple dialog with options', fakeAsync(() => {
+  it('#should have "close" for button action', () => {
+    const dialogRef = dialog.open(SimpleDialog);
+    viewContainerFixture.detectChanges();
+
+    expect(dialogRef.componentInstance.buttonAction).toBe('close');
+  });
+
+  it('#should have null for button action', () => {
+    const dialogRef = dialog.open(SimpleDialog);
+    dialogRef.componentInstance.buttonAction = null;
+    viewContainerFixture.detectChanges();
+
+    expect(dialogRef.componentInstance.buttonAction).toBe(null);
+  });
+
+  // it('#should handle keydown event', fakeAsync(() => {
+  //   const dialogRef = dialog.open(DialogWithDefaultButton);
+  //   dispatchKeyboardEvent(overlayContainerElement.querySelector('mdc-dialog'), 'keydown', A);
+  //   tick(500);
+  //   viewContainerFixture.detectChanges();
+  // }));
+
+  it('#should handle default button click', () => {
+    const dialogRef = dialog.open(DialogWithDefaultButton);
+    const actionButtonDebugElement = overlayContainerElement.querySelector('button');
+    dispatchFakeEvent(actionButtonDebugElement, 'click');
+
+    viewContainerFixture.detectChanges();
+  });
+
+  it('#should open a dialog with no buttons', () => {
+    const dialogRef = dialog.open(DialogWithNoButtons);
+    viewContainerFixture.detectChanges();
+  });
+
+  it('#should open a simple dialog with options', () => {
     const dialogRef = dialog.open(SimpleDialog, {
       clickOutsideToClose: false,
       escapeToClose: false,
       buttonsStacked: false
     });
     viewContainerFixture.detectChanges();
-    flush();
 
     dispatchKeyboardEvent(overlayContainerElement, 'keydown', DOWN_ARROW);
-
     expect(dialogRef.componentInstance.dialogRef).toBe(dialogRef);
+  });
+
+  it('should notify the observers if all open dialogs have finished closing', fakeAsync(() => {
+    const ref1 = dialog.open(PizzaMsg, { viewContainerRef: testViewContainerRef });
+    const ref2 = dialog.open(SimpleDialog, { viewContainerRef: testViewContainerRef });
+    const spy = jasmine.createSpy('afterAllClosed spy');
+
+    dialog.afterAllClosed.subscribe(spy);
+
+    ref1.close();
+    viewContainerFixture.detectChanges();
+    flush();
+
+    expect(spy).not.toHaveBeenCalled();
+
+    ref2.close();
+    viewContainerFixture.detectChanges();
+    flush();
+    expect(spy).toHaveBeenCalled();
   }));
 
-  it('should close a dialog and get back a result', fakeAsync(() => {
+  it('should close a dialog and get back a result', () => {
     const afterCloseCallback = jasmine.createSpy('afterClose callback');
     const dialogRef = dialog.open(SimpleDialog);
 
@@ -131,9 +184,17 @@ describe('MdcDialog Service', () => {
     dialogRef.close('Pizza');
 
     expect(afterCloseCallback).toHaveBeenCalledWith('Pizza');
-  }));
+  });
 
-  it('should complete open and close streams when the injectable is destroyed', fakeAsync(() => {
+  it('should emit the afterAllClosed stream on subscribe if there are no open dialogs', () => {
+    const spy = jasmine.createSpy('afterAllClosed spy');
+
+    dialog.afterAllClosed.subscribe(spy);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should complete open and close streams when the injectable is destroyed', () => {
     const afterOpenedSpy = jasmine.createSpy('after opened spy');
     const afterAllClosedSpy = jasmine.createSpy('after all closed spy');
     const afterOpenedSubscription = dialog.afterOpened.subscribe({ complete: afterOpenedSpy });
@@ -148,7 +209,7 @@ describe('MdcDialog Service', () => {
 
     afterOpenedSubscription.unsubscribe();
     afterAllClosedSubscription.unsubscribe();
-  }));
+  });
 
   it('#should close a simple dialog', () => {
     const dialogRef = dialog.open(SimpleDialog);
@@ -167,7 +228,7 @@ describe('MdcDialog Service', () => {
     }).toThrow();
   });
 
-  it('should close all of the dialogs', fakeAsync(() => {
+  it('should close all of the dialogs', () => {
     dialog.open(PizzaMsg);
     dialog.open(PizzaMsg);
     dialog.open(PizzaMsg);
@@ -176,9 +237,140 @@ describe('MdcDialog Service', () => {
 
     dialog.closeAll();
     viewContainerFixture.detectChanges();
-    flush();
 
     expect(overlayContainerElement.querySelectorAll('mdc-dialog-portal').length).toBe(0);
+  });
+
+  it('should have the componentInstance available in the afterClosed callback', fakeAsync(() => {
+    const dialogRef = dialog.open(PizzaMsg);
+    const spy = jasmine.createSpy('afterClosed spy');
+
+    flushMicrotasks();
+    viewContainerFixture.detectChanges();
+    flushMicrotasks();
+
+    dialogRef.afterClosed().subscribe(() => {
+      spy();
+      expect(dialogRef.componentInstance).toBeTruthy('Expected component instance to be defined.');
+    });
+
+    dialogRef.close();
+
+    flushMicrotasks();
+    viewContainerFixture.detectChanges();
+    tick(500);
+
+    // Ensure that the callback actually fires.
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  describe('passing in data', () => {
+    it('should be able to pass in data', () => {
+      const config = {
+        data: {
+          stringParam: 'hello',
+          dateParam: new Date()
+        }
+      };
+
+      const instance = dialog.open(DialogWithInjectedData, config).componentInstance;
+
+      expect(instance.data.stringParam).toBe(config.data.stringParam);
+      expect(instance.data.dateParam).toBe(config.data.dateParam);
+    });
+
+    it('should default to null if no data is passed', () => {
+      expect(() => {
+        const dialogRef = dialog.open(DialogWithInjectedData);
+        expect(dialogRef.componentInstance.data).toBeNull();
+      }).not.toThrow();
+    });
+  });
+});
+
+describe('MdcDialog with a parent MdcDialog', () => {
+  let parentDialog: MdcDialog;
+  let childDialog: MdcDialog;
+  let overlayContainerElement: HTMLElement;
+  let fixture: ComponentFixture<ComponentThatProvidesMdcDialog>;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MdcDialogModule, DialogTestModule],
+      declarations: [ComponentThatProvidesMdcDialog],
+      providers: [
+        {
+          provide: OverlayContainer, useFactory: () => {
+            overlayContainerElement = document.createElement('div');
+            return { getContainerElement: () => overlayContainerElement };
+          }
+        },
+        { provide: Location, useClass: SpyLocation }
+      ],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  beforeEach(inject([MdcDialog], (d: MdcDialog) => {
+    parentDialog = d;
+
+    fixture = TestBed.createComponent(ComponentThatProvidesMdcDialog);
+    childDialog = fixture.componentInstance.dialog;
+    fixture.detectChanges();
+  }));
+
+  afterEach(() => {
+    overlayContainerElement.innerHTML = '';
+  });
+
+  it('should close dialogs opened by a parent when calling closeAll on a child MdcDialog',
+    fakeAsync(() => {
+      parentDialog.open(PizzaMsg);
+      fixture.detectChanges();
+      flush();
+
+      expect(overlayContainerElement.textContent)
+        .toContain('Pizza', 'Expected a dialog to be opened');
+
+      childDialog.closeAll();
+      fixture.detectChanges();
+      flush();
+
+      expect(overlayContainerElement.textContent!.trim())
+        .toBe('', 'Expected closeAll on child MdcDialog to close dialog opened by parent');
+    }));
+
+  it('should close dialogs opened by a child when calling closeAll on a parent MdcDialog',
+    fakeAsync(() => {
+      childDialog.open(PizzaMsg);
+      fixture.detectChanges();
+
+      expect(overlayContainerElement.textContent)
+        .toContain('Pizza', 'Expected a dialog to be opened');
+
+      parentDialog.closeAll();
+      fixture.detectChanges();
+      flush();
+
+      expect(overlayContainerElement.textContent!.trim())
+        .toBe('', 'Expected closeAll on parent MdcDialog to close dialog opened by child');
+    }));
+
+  it('should not close the parent dialogs when a child is destroyed', fakeAsync(() => {
+    parentDialog.open(PizzaMsg);
+    fixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.textContent)
+      .toContain('Pizza', 'Expected a dialog to be opened');
+
+    childDialog.ngOnDestroy();
+    fixture.detectChanges();
+    flush();
+
+    expect(overlayContainerElement.textContent)
+      .toContain('Pizza', 'Expected a dialog to be opened');
   }));
 });
 
@@ -233,21 +425,76 @@ class PizzaMsg {
           Let Google help apps determine location.
         </mdc-dialog-content>
         <mdc-dialog-actions stacked>
-          <button mdcDialogButton mdcDialogAction="close">Decline</button>
+          <button mdcDialogButton #decline [mdcDialogAction]="buttonAction">Decline</button>
           <button mdcDialogButton mdcDialogAction>Do Nothing</button>
           <button mdcDialogButton default mdcDialogAction="accept">Accept</button>
         </mdc-dialog-actions>
       </mdc-dialog-surface>
     </mdc-dialog-container>
-  </mdc-dialog>
-  `,
+  </mdc-dialog>`,
 })
 class SimpleDialog {
   constructor(public dialogRef: MdcDialogRef<SimpleDialog>) { }
+
+  buttonAction: string = 'close';
+}
+
+@Component({
+  template: `
+  <mdc-dialog>
+    <mdc-dialog-container>
+      <mdc-dialog-surface>
+        <mdc-dialog-title>Use Google's location service?</mdc-dialog-title>
+        <mdc-dialog-content>
+          Let Google help apps determine location.
+        </mdc-dialog-content>
+        <mdc-dialog-actions stacked>
+          <button mdcDialogButton default mdcDialogAction="accept">Accept</button>
+        </mdc-dialog-actions>
+      </mdc-dialog-surface>
+    </mdc-dialog-container>
+  </mdc-dialog>`,
+})
+class DialogWithDefaultButton {
+  constructor(public dialogRef: MdcDialogRef<DialogWithDefaultButton>) { }
+}
+
+@Component({
+  template: `
+  <mdc-dialog>
+    <mdc-dialog-container>
+      <mdc-dialog-surface>
+        <mdc-dialog-title>Use Google's location service?</mdc-dialog-title>
+        <mdc-dialog-content>
+          Let Google help apps determine location.
+        </mdc-dialog-content>
+      </mdc-dialog-surface>
+    </mdc-dialog-container>
+  </mdc-dialog>`,
+})
+class DialogWithNoButtons {
+  constructor(public dialogRef: MdcDialogRef<DialogWithNoButtons>) { }
+}
+
+/** Simple component for testing ComponentPortal. */
+@Component({ template: '' })
+class DialogWithInjectedData {
+  constructor(@Inject(MDC_DIALOG_DATA) public data: any) { }
+}
+
+@Component({
+  template: '',
+  providers: [MdcDialog]
+})
+class ComponentThatProvidesMdcDialog {
+  constructor(public dialog: MdcDialog) { }
 }
 
 const TEST_DIRECTIVES = [
   SimpleDialog,
+  DialogWithDefaultButton,
+  DialogWithNoButtons,
+  DialogWithInjectedData,
   PizzaMsg,
   ComponentWithTemplateRef,
   ComponentWithChildViewContainer,
@@ -260,6 +507,9 @@ const TEST_DIRECTIVES = [
   declarations: TEST_DIRECTIVES,
   entryComponents: [
     SimpleDialog,
+    DialogWithDefaultButton,
+    DialogWithNoButtons,
+    DialogWithInjectedData,
     ComponentWithTemplateRef,
     PizzaMsg,
     ComponentWithChildViewContainer

--- a/test/form-field/form-field.test.ts
+++ b/test/form-field/form-field.test.ts
@@ -9,7 +9,9 @@ import {
   MdcFormFieldModule,
   MdcCheckboxModule,
   MdcRadioModule,
-  MdcSwitchModule
+  MdcSwitchModule,
+  MdcTextFieldModule,
+  MdcFormFieldVariant
 } from '@angular-mdc/web';
 
 describe('MdcFormField', () => {
@@ -21,10 +23,12 @@ describe('MdcFormField', () => {
         MdcFormFieldModule,
         MdcCheckboxModule,
         MdcRadioModule,
-        MdcSwitchModule
+        MdcSwitchModule,
+        MdcTextFieldModule
       ],
       declarations: [
         SimpleTest,
+        FormFieldWithTextField
       ]
     });
     TestBed.compileComponents();
@@ -64,33 +68,80 @@ describe('MdcFormField', () => {
       flush();
     }));
   });
+
+  describe('FormFieldWithTextField', () => {
+    let testDebugElement: DebugElement;
+    let testNativeElement: HTMLElement;
+    let testInstance: MdcFormField;
+    let testComponent: FormFieldWithTextField;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(FormFieldWithTextField);
+      fixture.detectChanges();
+
+      testDebugElement = fixture.debugElement.query(By.directive(MdcFormField));
+      testNativeElement = testDebugElement.nativeElement;
+      testInstance = testDebugElement.componentInstance;
+      testComponent = fixture.debugElement.componentInstance;
+    });
+
+    it('#should contain ngx-form-field-text-field class', () => {
+      expect(testDebugElement.nativeElement.classList).toContain('ngx-form-field-text-field');
+    });
+
+    it('#should not have a label set', () => {
+      expect(testInstance.label).toBeUndefined();
+    });
+
+    it('#should set helper-text persistent to true', () => {
+      testComponent.persistent = true;
+      fixture.detectChanges();
+      expect(testInstance.assistiveElements.toArray()[0].persistent).toBe(true);
+    });
+
+    it('#should set variant to outlined', () => {
+      testComponent.variant = 'outlined';
+      fixture.detectChanges();
+      expect(testInstance.variant).toBe('outlined');
+    });
+  });
 });
 
 @Component({
   template: `
-    <mdc-form-field [alignEnd]="alignEnd" [fluid]="fluid">
-      <mdc-checkbox></mdc-checkbox>
-      <label>My label</label>
-    </mdc-form-field>
-    <mdc-form-field>
-      <mdc-radio></mdc-radio>
-      <label>My label</label>
-    </mdc-form-field>
-    <mdc-form-field>
-      <mdc-switch></mdc-switch>
-      <label>My label</label>
-    </mdc-form-field>
-    <mdc-form-field>
-      <mdc-switch></mdc-switch>
-    </mdc-form-field>
-    <mdc-form-field>
-      <mdc-switch></mdc-switch>
-      <span>not a label</span>
-    </mdc-form-field>
-    <mdc-form-field></mdc-form-field>
-  `,
+  <mdc-form-field [alignEnd]="alignEnd" [fluid]="fluid">
+    <mdc-checkbox></mdc-checkbox>
+    <label>My label</label>
+  </mdc-form-field>
+  <mdc-form-field>
+    <mdc-radio></mdc-radio>
+    <label>My label</label>
+  </mdc-form-field>
+  <mdc-form-field>
+    <mdc-switch></mdc-switch>
+    <label>My label</label>
+  </mdc-form-field>
+  <mdc-form-field>
+    <mdc-switch></mdc-switch>
+  </mdc-form-field>
+  <mdc-form-field>
+    <mdc-switch></mdc-switch>
+    <span>not a label</span>
+  </mdc-form-field>
+  <mdc-form-field></mdc-form-field>`,
 })
 class SimpleTest {
   alignEnd: boolean = false;
   fluid: boolean;
+}
+
+@Component({
+  template: `<mdc-form-field [variant]="variant">
+  <mdc-text-field label="First name" outlined required></mdc-text-field>
+  <mdc-helper-text [persistent]="persistent" validation>*Required</mdc-helper-text>
+</mdc-form-field>`
+})
+class FormFieldWithTextField {
+  variant: MdcFormFieldVariant;
+  persistent: boolean;
 }

--- a/test/menu-surface/menu-surface.test.ts
+++ b/test/menu-surface/menu-surface.test.ts
@@ -1,15 +1,10 @@
 import { Component, DebugElement } from '@angular/core';
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { dispatchFakeEvent, dispatchMouseEvent, dispatchKeyboardEvent } from '../testing/dispatch-events';
-
 import {
-  TAB,
-  DOWN_ARROW,
   MdcMenuSurface,
   MdcMenuSurfaceModule,
-  MdcMenuSurfaceAnchor,
   MdcImageListModule,
   Platform
 } from '@angular-mdc/web';
@@ -100,18 +95,6 @@ describe('MdcMenuSurface', () => {
       testDebugElement.nativeElement.click();
       fixture.detectChanges();
     });
-
-    it('#should handle window object click event', fakeAsync(() => {
-      testComponent.open = true;
-      fixture.detectChanges();
-      tick(500);
-
-      dispatchMouseEvent(document, 'click');
-      fixture.detectChanges();
-      tick(500);
-
-      expect(testInstance.open).toBe(false);
-    }));
   });
 });
 
@@ -132,7 +115,7 @@ describe('MdcMenuSurface', () => {
       <mdc-image-list>
         <mdc-image-list-item *ngFor="let i of images">
           <mdc-image-list-image-aspect>
-            <img mdcImageListImage src="https://material-components-web.appspot.com/images/photos/3x2/{{i+1}}.jpg" />
+            <img mdcImageListImage />
           </mdc-image-list-image-aspect>
           <mdc-image-list-supporting>
             <span mdcImageListLabel>Text label</span>


### PR DESCRIPTION
WIP

- [x] Adds `type = MdcFormFieldVariant = 'fullwidth' | 'outlined' | undefined;`
- [ ] Investigate which variants are most appropriate for `MdcFormFieldVariant`
- [x] Adds `MdcFormFieldDefaultOptions` interface for configuring default options
- [ ] Apply default options for `mdc-select`, `mdc-text-field`
- [ ] Investigate implications for `mdc-checkbox`, `mdc-radio` and `mdc-switch`
- [ ] Add documentation
- [ ] Include unit tests

closes #1798