### PR TITLE
feat(slider): add minmax property

### DIFF
--- a/demos/src/app/components/slider-demo/api.html
+++ b/demos/src/app/components/slider-demo/api.html
@@ -24,6 +24,10 @@
         <td>The maximum value that the slider can have.</td>
       </tr>
       <tr>
+          <td>minmax: \[number, number\]</td>
+          <td>Combination of *min* and *max* set at once to avoid any incompatibility with existing settings.</td>
+      </tr>
+      <tr>
         <td>value: number</td>
         <td>The current value of the slider.</td>
       </tr>

--- a/packages/slider/slider.ts
+++ b/packages/slider/slider.ts
@@ -132,6 +132,34 @@ export class MdcSlider extends MDCComponent<MDCSliderFoundation>
   private _max: number = 100;
 
   @Input()
+  get minmax(): [number, number] { return [this._min, this._max]; }
+  set minmax(mm: [number, number]) {
+      const newmin = coerceNumberProperty(mm[0], this._min);
+      const newmax = coerceNumberProperty(mm[1], this._max);
+      if (newmax < newmin) { return; }
+
+      const updateFoundation = this._foundation && this._initialized;
+      let dirty = false;
+      if (newmin !== this._min) {
+          this._min = newmin;
+          if (updateFoundation) {
+              this._foundation.setMin(this._min);
+              dirty = true;
+          }
+      }
+      if (newmax !== this._max) {
+          this._max = newmax;
+          if (updateFoundation) {
+              this._foundation.setMax(this._max);
+              dirty = true;
+          }
+      }
+      if (dirty) {
+          this._changeDetectorRef.markForCheck();
+      }
+  }
+
+  @Input()
   get step(): number { return this._step; }
   set step(value: number) {
     const step = coerceNumberProperty(value, this._step);

--- a/test/slider/slider.test.ts
+++ b/test/slider/slider.test.ts
@@ -70,6 +70,34 @@ describe('MdcSlider', () => {
       fixture.detectChanges();
       expect(sliderInstance.max).toBe(200);
     });
+
+    it('#should set minmax inside default range', () => {
+        const defaultMin = sliderInstance.min;
+        const defaultMax = sliderInstance.max;
+        const newMin = defaultMin + 1;
+        const newMax = defaultMax - 1;
+        sliderInstance.minmax = [newMin, newMax];
+        expect(sliderInstance.min).toBe(newMin);
+        expect(sliderInstance.max).toBe(newMax);
+    });
+
+    it('#should set minmax above default max', () => {
+        const defaultMax = sliderInstance.max;
+        const newMin = defaultMax + 10;
+        const newMax = newMin + 10;
+        sliderInstance.minmax = [newMin, newMax];
+        expect(sliderInstance.min).toBe(newMin);
+        expect(sliderInstance.max).toBe(newMax);
+    });
+
+    it('#should set minmax below default min', () => {
+        const defaultMin = sliderInstance.min;
+        const newMax = defaultMin - 10;
+        const newMin = newMax - 10;
+        sliderInstance.minmax = [newMin, newMax];
+        expect(sliderInstance.min).toBe(newMin);
+        expect(sliderInstance.max).toBe(newMax);
+    });
   });
 
   describe('basic behaviors', () => {


### PR DESCRIPTION
This is intended to address #2019.

There are probably ways to do this without adding an additional property binding, but I couldn't think of any that didn't add additional surprise. The fundamental problem seems to be that existing values are used for sanity checking on new ones, which setting them as a unit avoids.