### PR TITLE
Drawer. Suppress only escape key

### DIFF
--- a/packages/drawer/drawer.ts
+++ b/packages/drawer/drawer.ts
@@ -226,7 +226,7 @@ export class MdcDrawer extends MDCComponent<MDCDismissibleDrawerFoundation | MDC
       (fromEvent(this._elementRef.nativeElement, 'keydown') as Observable<KeyboardEvent>)
         .pipe(takeUntil(this._destroyed)).subscribe(event => this._ngZone.run(() => {
           this._foundation.handleKeydown(event);
-          if (this.modal) {
+          if (this.modal && (event.key === 'Escape' || event.key === 'Esc')) {
             event.stopPropagation();
             event.preventDefault();
           }


### PR DESCRIPTION
If we want to put text input's into the drawer then at the moment keypresses are eaten up (preventDefault-ed).
This PR only eats up the escape key coming from drawer.